### PR TITLE
Update command builder for non-windows, add '=' to target

### DIFF
--- a/src/cake.ts
+++ b/src/cake.ts
@@ -42,7 +42,7 @@ export class Cake {
         } else {
             const sh = path.join(root, "build.sh")
             if (fs.existsSync(sh)) {
-                return `./build.sh --target \"${taskName}\"`
+                return `./build.sh --target=\"${taskName}\"`
             } else {
                 return `cake -target=\"${taskName}\"`
             }


### PR DESCRIPTION
On MacOS the command generated by the cake runner doesn't execute unless we add the equals sign (=) after `--target` to the command ourselfes. 