### PR TITLE
Fixed script for build.cake 0.33.0

### DIFF
--- a/src/cake.ts
+++ b/src/cake.ts
@@ -35,7 +35,7 @@ export class Cake {
         if (windows) {
             const ps1 = path.join(root, "build.ps1")
             if (fs.existsSync(ps1)) {
-                return `powershell -ExecutionPolicy ByPass -File build.ps1 -target \"${taskName}\"`
+                return `powershell -ExecutionPolicy ByPass -File build.ps1 -target=\"${taskName}\"`
             } else {
                 return `cake -target=\"${taskName}\"`
             }


### PR DESCRIPTION
Build.cake 0.33.0 requires an = between `-target` and the task. This is backwards compatible with previous versions of build cake as well.